### PR TITLE
Allow the configuration of the ports via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Clone repo and run `npm install` in the root directory.
 Default path is your current working directory.  Override by passing an optional path to your desired web root directory.
 
 ### Default ports
-Default ports are `3000` (http) and `3001` (https).  These can be changed in `index.js`.
+These can be changed by passing through environment variables when starting the server:
+`SSWS_HTTP_PORT` = http port (defaults to `3000`)
+`SSWS_HTTPS_PORT` = https port (defaults to `3001`)
 
 ### Default IP
 The default IP `127.0.0.1` which should convieniently map to `localhost`.

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const util = require('util');
 const os = require('os');
 
 const USE_LOCALHOST = true;
-const HTTP_PORT = 3000;
-const HTTPS_PORT = 3001;
+const HTTP_PORT = process.env.SSWS_HTTP_PORT || 3000;
+const HTTPS_PORT = process.env.SSWS_HTTPS_PORT || 3001;
 const KEY_PATH = 'certs/key.pem';
 const CERT_PATH = 'certs/cert.pem';
 


### PR DESCRIPTION
The default behaviour of `3000` / `3001` remains the same.
This will help work towards resolving this outstanding issue: https://github.com/garris/ember-backstop/issues/34